### PR TITLE
Focus handlers

### DIFF
--- a/linearcontainer/container.go
+++ b/linearcontainer/container.go
@@ -1,0 +1,5 @@
+package linearcontainer
+
+type Container interface {
+	GetChildren() []*ChildComponent
+}

--- a/linearcontainer/focushandler.go
+++ b/linearcontainer/focushandler.go
@@ -35,3 +35,19 @@ type FocusHandler interface {
 	*/
 	UpdateFocusedChild() FocusHandler
 }
+
+/*
+Returns a slice of the components' (including their child components, if they have any)
+that are capable of receiving focus
+*/
+func GetFocusableComponents(components []*ChildComponent) (output []*ChildComponent) {
+	for _, component := range components {
+		if component.IsFocusable() {
+			output = append(output, component)
+		}
+		if lc, isLC := component.GetModel().(Container); isLC {
+			output = append(output, GetFocusableComponents(lc.GetChildren())...)
+		}
+	}
+	return
+}

--- a/linearcontainer/focushandler.go
+++ b/linearcontainer/focushandler.go
@@ -1,0 +1,37 @@
+package linearcontainer
+
+/*
+FocusHandler keeps track of which child component has focus and
+determines how focus behaves
+*/
+type FocusHandler interface {
+	/*
+		Checks if a given string represents a key combination
+		that the focus handler uses to change focus
+	*/
+	IsFocusKey(string) bool
+	/*
+		Updates which child component has focus based on the
+		given key combination
+	*/
+	HandleFocusKey(string) FocusHandler
+	/*
+		Returns the component that currently has focus
+	*/
+	GetFocusedComponent() *ChildComponent
+	/*
+		Returns the focus handler with a given container as its
+		subject. The subject being the UI element whose focus
+		the focus manager is managing
+	*/
+	SetSubjectContainer(Container) FocusHandler
+	/*
+		Returns the focus handler with a given ChildComponent pointer
+		as its currently focused component
+	*/
+	SetFocusedComponent(*ChildComponent) FocusHandler
+	/*
+		Returns the focus handler after having updated its focused child
+	*/
+	UpdateFocusedChild() FocusHandler
+}

--- a/linearcontainer/linearfocushandler.go
+++ b/linearcontainer/linearfocushandler.go
@@ -55,22 +55,6 @@ func (lfh linearFocusHandler) SetFocusedComponent(child *ChildComponent) FocusHa
 }
 
 /*
-Returns a slice of the components' (including their child components, if they have any)
-that are capable of receiving focus
-*/
-func GetFocusableComponents(components []*ChildComponent) (output []*ChildComponent) {
-	for _, component := range components {
-		if component.IsFocusable() {
-			output = append(output, component)
-		}
-		if lc, isLC := component.GetModel().(Container); isLC {
-			output = append(output, GetFocusableComponents(lc.GetChildren())...)
-		}
-	}
-	return
-}
-
-/*
 Returns a FocusHandler whose focused child pointer has been updated according
 to this current focus index and the subject container's focusable children
 */

--- a/linearcontainer/linearfocushandler.go
+++ b/linearcontainer/linearfocushandler.go
@@ -1,0 +1,112 @@
+package linearcontainer
+
+import (
+	"slices"
+
+	utils "github.com/argotnaut/vanitea/utils"
+)
+
+const (
+	FOCUS_FORWARD  = "tab"
+	FOCUS_BACKWARD = "shift+tab"
+)
+
+/*
+Handles the transfer of focus from one of a container's child components to the
+next in a sequence determined by the container's layout hierarchy
+*/
+type linearFocusHandler struct {
+	// The index of the currently focused component in the list of focusable components
+	focusIndex int
+	// A pointer to the currently focused component
+	focusedChild *ChildComponent
+	// A slice of strings representing the key combinations that can be pressed to affect focus
+	focusKeys []string
+	// The container whose child components' focus is being handled
+	subjectContainer Container
+}
+
+func NewLinearFocusHandler() linearFocusHandler {
+	lfh := linearFocusHandler{
+		focusKeys: []string{FOCUS_FORWARD, FOCUS_BACKWARD},
+	}
+	return lfh
+}
+
+func (lfh linearFocusHandler) SetSubjectContainer(subject Container) FocusHandler {
+	lfh.subjectContainer = subject
+	return lfh
+}
+
+/*
+Returns true if the given string represents a key combination that can affect focus
+*/
+func (lfh linearFocusHandler) IsFocusKey(key string) bool {
+	return slices.Contains(lfh.focusKeys, key)
+}
+
+func (lfh linearFocusHandler) GetFocusedComponent() *ChildComponent {
+	return lfh.focusedChild
+}
+
+func (lfh linearFocusHandler) SetFocusedComponent(child *ChildComponent) FocusHandler {
+	lfh.focusedChild = child
+	return lfh
+}
+
+/*
+Returns a slice of the components' (including their child components, if they have any)
+that are capable of receiving focus
+*/
+func GetFocusableComponents(components []*ChildComponent) (output []*ChildComponent) {
+	for _, component := range components {
+		if component.IsFocusable() {
+			output = append(output, component)
+		}
+		if lc, isLC := component.GetModel().(Container); isLC {
+			output = append(output, GetFocusableComponents(lc.GetChildren())...)
+		}
+	}
+	return
+}
+
+/*
+Returns a FocusHandler whose focused child pointer has been updated according
+to this current focus index and the subject container's focusable children
+*/
+func (lfh linearFocusHandler) UpdateFocusedChild() FocusHandler {
+	if lfh.subjectContainer == nil {
+		return lfh
+	}
+	focusables := GetFocusableComponents(lfh.subjectContainer.GetChildren())
+	lfh.focusIndex = utils.WrapInt(lfh.focusIndex, 0, len(focusables))
+	lfh.focusedChild = focusables[lfh.focusIndex]
+	return lfh
+}
+
+func (lfh linearFocusHandler) setFocusIndex(focusIndex int) FocusHandler {
+	lfh.focusIndex = focusIndex
+	return lfh.UpdateFocusedChild()
+}
+
+func (lfh linearFocusHandler) focusForward() FocusHandler {
+	return lfh.setFocusIndex(lfh.focusIndex + 1)
+}
+
+func (lfh linearFocusHandler) focusBackward() FocusHandler {
+	return lfh.setFocusIndex(lfh.focusIndex - 1)
+}
+
+func (lfh linearFocusHandler) ChildIsFocused(child *ChildComponent) bool {
+	return child == lfh.focusedChild
+}
+
+func (lfh linearFocusHandler) HandleFocusKey(key string) FocusHandler {
+	switch key {
+	case FOCUS_FORWARD:
+		return lfh.focusForward()
+	case FOCUS_BACKWARD:
+		return lfh.focusBackward()
+	}
+	return lfh
+}


### PR DESCRIPTION
This branch adds a `FocusHandler` interface to manage which child component has focus within a container. It implements a `linearFocusHandler` which allows users to iterate through the hierarchy of child components within a nested list of containers linearly (by pressing `tab`/`shift+tab`)

[linearFocusHandler.webm](https://github.com/user-attachments/assets/ae5718a9-bace-432d-a0c4-a91da310ac48)
