### PR TITLE
16 shrink to contents

### DIFF
--- a/container/component.go
+++ b/container/component.go
@@ -382,10 +382,18 @@ func (m Component) GetClampedWidth(inputWidth int) int {
 	)
 }
 
+/*
+Whether the component should be given more space than its
+model will use (when being layed-out)
+*/
 func (m Component) ShrinkToContent() bool {
 	return m.shrinkToContent
 }
 
+/*
+Sets whether the component should be given more space than its
+model will use (when being layed-out)
+*/
 func (m *Component) SetShrinkToContent(input bool) *Component {
 	m.shrinkToContent = input
 	return m
@@ -429,19 +437,14 @@ Truncates the given TUI element to a width and height given by a tea.WindowSizeM
 sizeLimit: tea.WindowSizeMsg - The width and height to truncate the TUI element to
 input: string - The TUI element to truncate
 */
-func limitSize(sizeLimit tea.WindowSizeMsg, input string) string {
+func (m Component) limitSize(sizeLimit tea.WindowSizeMsg, input string) string {
 	style := lipgloss.DefaultRenderer().NewStyle().
 		MaxWidth(sizeLimit.Width).
-		Width(sizeLimit.Width).
 		MaxHeight(sizeLimit.Height)
+	if !m.ShrinkToContent() {
+		style = style.Width(sizeLimit.Width)
+	}
 	return style.Render(input)
-}
-
-func limitSizeWithoutSetting(sizeLimit tea.WindowSizeMsg, input string) string {
-	return lipgloss.DefaultRenderer().NewStyle().
-		MaxWidth(sizeLimit.Width).
-		MaxHeight(sizeLimit.Height).
-		Render(input)
 }
 
 /*
@@ -458,13 +461,8 @@ func (m Component) render(focused bool) string {
 	renderSize := m.GetSize()
 	renderSize.Height = max(0, renderSize.Height-currentStyle.GetVerticalFrameSize())
 	renderSize.Width = max(0, renderSize.Width-currentStyle.GetHorizontalFrameSize())
-	limitSizeFunction := limitSize
-	// DEBUG:
-	if m.ShrinkToContent() {
-		limitSizeFunction = limitSizeWithoutSetting
-	}
 	view := currentStyle.Render(
-		limitSizeFunction(
+		m.limitSize(
 			renderSize,
 			m.GetModel().View(),
 		),
@@ -490,10 +488,10 @@ func (m Component) render(focused bool) string {
 	startOfLastLine := strings.LastIndex(view, "\n") + len("\n") // The start of the last line, which should be the bottom of the border
 
 	sizeLimit := tea.WindowSizeMsg{Width: lipgloss.Width(view[:endOfFirstLine]) - 2, Height: 1}
-	topRightText := strings.TrimSpace(limitSize(sizeLimit, getTextForCorner(TOP_RIGHT)))
-	topLeftText := strings.TrimSpace(limitSize(sizeLimit, getTextForCorner(TOP_LEFT)))
-	bottomLeftText := strings.TrimSpace(limitSize(sizeLimit, getTextForCorner(BOTTOM_LEFT)))
-	bottomRightText := strings.TrimSpace(limitSize(sizeLimit, getTextForCorner(BOTTOM_RIGHT)))
+	topRightText := strings.TrimSpace(m.limitSize(sizeLimit, getTextForCorner(TOP_RIGHT)))
+	topLeftText := strings.TrimSpace(m.limitSize(sizeLimit, getTextForCorner(TOP_LEFT)))
+	bottomLeftText := strings.TrimSpace(m.limitSize(sizeLimit, getTextForCorner(BOTTOM_LEFT)))
+	bottomRightText := strings.TrimSpace(m.limitSize(sizeLimit, getTextForCorner(BOTTOM_RIGHT)))
 
 	var output strings.Builder
 

--- a/container/component.go
+++ b/container/component.go
@@ -86,6 +86,8 @@ type Component struct {
 	shortcutPosition int
 	// Any Actions associated with the component
 	actions []Action
+	// Will shrink to fit its content when layed-out
+	shrinkToContent bool
 }
 
 /*
@@ -364,6 +366,15 @@ func (m Component) GetSize() tea.WindowSizeMsg {
 	}
 }
 
+func (m Component) ShrinkToContent() bool {
+	return m.shrinkToContent
+}
+
+func (m *Component) SetShrinkToContent(input bool) *Component {
+	m.shrinkToContent = input
+	return m
+}
+
 /*
 This function calls Component.Model.Update function and returns
 the result. If the given message is a tea.WindowSizeMsg, it will
@@ -410,6 +421,13 @@ func limitSize(sizeLimit tea.WindowSizeMsg, input string) string {
 	return style.Render(input)
 }
 
+func limitSizeWithoutSetting(sizeLimit tea.WindowSizeMsg, input string) string {
+	return lipgloss.DefaultRenderer().NewStyle().
+		MaxWidth(sizeLimit.Width).
+		MaxHeight(sizeLimit.Height).
+		Render(input)
+}
+
 /*
 Renders the component's model according to it's current properties
 and with the correct focus styling
@@ -424,8 +442,13 @@ func (m Component) render(focused bool) string {
 	renderSize := m.GetSize()
 	renderSize.Height = max(0, renderSize.Height-currentStyle.GetVerticalFrameSize())
 	renderSize.Width = max(0, renderSize.Width-currentStyle.GetHorizontalFrameSize())
+	limitSizeFunction := limitSize
+	// DEBUG:
+	if m.ShrinkToContent() {
+		limitSizeFunction = limitSizeWithoutSetting
+	}
 	view := currentStyle.Render(
-		limitSize(
+		limitSizeFunction(
 			renderSize,
 			m.GetModel().View(),
 		),

--- a/container/component.go
+++ b/container/component.go
@@ -366,6 +366,22 @@ func (m Component) GetSize() tea.WindowSizeMsg {
 	}
 }
 
+func (m Component) GetClampedHeight(inputHeight int) int {
+	return utils.ClampInt(
+		inputHeight,
+		m.GetMinimumHeight(),
+		m.GetMaximumHeight(),
+	)
+}
+
+func (m Component) GetClampedWidth(inputWidth int) int {
+	return utils.ClampInt(
+		inputWidth,
+		m.GetMinimumWidth(),
+		m.GetMaximumWidth(),
+	)
+}
+
 func (m Component) ShrinkToContent() bool {
 	return m.shrinkToContent
 }

--- a/examples/imageview/tui/ansiinfo.go
+++ b/examples/imageview/tui/ansiinfo.go
@@ -43,7 +43,7 @@ func NewANSIInfoModel() (output ANSIInfoModel) {
 	output.container = lc.NewLinearContainerFromComponents(
 		[]*con.Component{
 			output.codeList.SetBorderStyle(con.NO_BORDER_STYLE),
-			output.image.SetFocusable(false),
+			output.image.SetFocusable(false).SetShrinkToContent(true),
 		},
 	).SetDirection(lc.HORIZONTAL)
 	return

--- a/examples/imageview/tui/ansiinfo.go
+++ b/examples/imageview/tui/ansiinfo.go
@@ -11,16 +11,23 @@ import (
 )
 
 //go:embed terminal.jpg
-var terminalImage []byte
+var terminalImage []byte // https://en.wikipedia.org/wiki/File:DEC_VT100_terminal.jpg
 
+/*
+A TUI component that lists ANSI escape codes. This is an example of how a user interface might be layed-out
+*/
 type ANSIInfoModel struct {
-	codeList  *con.Component
-	image     *con.Component
-	container *lc.LinearContainerModel
+	codeList  *con.Component           // The list of ANSI codes on the left of the component
+	image     *con.Component           // The image of a DEC VT100 terminal
+	container *lc.LinearContainerModel // The linear container which lays-out the above components
 }
 
+/*
+Returns an ANSIInfoModel initialized with some default values
+*/
 func NewANSIInfoModel() (output ANSIInfoModel) {
 
+	// Initialize the TUI list items
 	codeListItems := []list.Item{
 		codeItem{title: "ESC N", desc: "Single Shift Two"},
 		codeItem{title: "ESC O", desc: "Single Shift Three"},
@@ -32,18 +39,22 @@ func NewANSIInfoModel() (output ANSIInfoModel) {
 		codeItem{title: "ESC ^", desc: "Privacy Message"},
 		codeItem{title: "ESC _", desc: "Application Program Command"},
 	}
+	// create the TUI list
 	codeListModel := con.ComponentFromModel(
 		codeList{list: list.New(codeListItems, list.NewDefaultDelegate(), 0, 0)},
 	)
 	output.codeList = codeListModel
 
+	// create the TUI of the terminal image
 	output.image = con.ComponentFromModel(
 		iv.NewImageViewModelFromBytes(terminalImage),
 	)
+
+	// add both the list and the image components to a new linear container
 	output.container = lc.NewLinearContainerFromComponents(
 		[]*con.Component{
 			output.codeList.SetBorderStyle(con.NO_BORDER_STYLE),
-			output.image.SetFocusable(false).SetShrinkToContent(true),
+			output.image.SetFocusable(false).SetShrinkToContent(true), // the image component shouldn't grow beyond the size of the image that can be displayed
 		},
 	).SetDirection(lc.HORIZONTAL)
 	return

--- a/examples/imageview/tui/escapecodelist.go
+++ b/examples/imageview/tui/escapecodelist.go
@@ -1,3 +1,6 @@
+/*
+This file is largely boilerplate for a TUI list using bubbletea
+*/
 package tui
 
 import (

--- a/imageview/image.go
+++ b/imageview/image.go
@@ -6,9 +6,7 @@ import (
 	"image"
 	"image/draw"
 	"image/gif"
-	"io"
 	"log"
-	"net/http"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -25,6 +23,11 @@ const ANSI_RESET = "\x1b[0m"
 
 var InterpolationType = imaging.Lanczos
 
+/*
+Decodes a given slice of bytes into grid of color.Color values. The slice of bytes
+is expected to represent an image of one of the following types:
+gif, png, jpeg, bmp, or x-icon
+*/
 func decode(buf []byte) []image.Image {
 	mime, err := mimetype.DetectReader(bytes.NewReader(buf))
 	if err != nil {
@@ -106,6 +109,16 @@ func decode(buf []byte) []image.Image {
 	return frames
 }
 
+/*
+Given an image and a target size, returns an image scaled to that size.
+
+frames: []image.Image - A slice of grids of color.Color values, representing the image data
+
+targetSize: tea.WindowSizeMsg - The desired size of the output image. Size here is measured
+
+	in "pixels" where, because of the way the image is rendered with ASCII characters, a "pixel"
+	is 1x the width and 0.5x the height of a cell in the terminal
+*/
 func scale(frames []image.Image, targetSize tea.WindowSizeMsg) []image.Image {
 	type data struct {
 		i  int
@@ -130,6 +143,9 @@ func scale(frames []image.Image, targetSize tea.WindowSizeMsg) []image.Image {
 	return r
 }
 
+/*
+Given an image in the form of a slice of image.Image, return the ANSI-escaped 2D string slice
+*/
 func escape(frames []image.Image) [][]string {
 	type data struct {
 		i   int
@@ -184,6 +200,11 @@ func escape(frames []image.Image) [][]string {
 	return escaped
 }
 
+/*
+Given the current image dimensions and the bounding dimensions it needs
+to fit into, this function returns the largest dimensions the image could
+have while preserving its aspect ratio
+*/
 func rescaleImageToBounds(imageDimensions tea.WindowSizeMsg, bounds tea.WindowSizeMsg) (output tea.WindowSizeMsg) {
 	resizeRatio := min(
 		float64(bounds.Width)/float64(imageDimensions.Width),
@@ -194,6 +215,10 @@ func rescaleImageToBounds(imageDimensions tea.WindowSizeMsg, bounds tea.WindowSi
 	return output
 }
 
+/*
+Decodes a slice of bytes representing an image and returns a slice of
+image.Image
+*/
 func decodeImageBytes(image []byte) (output []image.Image, err error) {
 	if len(image) < 1 {
 		return output, fmt.Errorf("image bytes slice was empty")
@@ -202,6 +227,9 @@ func decodeImageBytes(image []byte) (output []image.Image, err error) {
 	return decodedImages, nil
 }
 
+/*
+Returns the width and height dimensions of a given image
+*/
 func getImageDimensions(image image.Image) tea.WindowSizeMsg {
 	return tea.WindowSizeMsg{
 		Height: image.Bounds().Dy(),
@@ -209,6 +237,10 @@ func getImageDimensions(image image.Image) tea.WindowSizeMsg {
 	}
 }
 
+/*
+Given an image and a target size, this function returns the image as
+an ANSI-escaped ASCII pixel string
+*/
 func getScaledImage(frames []image.Image, size *tea.WindowSizeMsg) string {
 	const ERROR_OUTPUT = "[-]"
 	if len(frames) < 1 {
@@ -225,26 +257,4 @@ func getScaledImage(frames []image.Image, size *tea.WindowSizeMsg) string {
 	)
 	output := escape(rescaledImage)
 	return strings.Join(output[0], "")
-}
-
-func getImageBytesFromURL(URL string) ([]byte, error) {
-	var resBody []byte
-	if strings.TrimSpace(URL) == "" {
-		return resBody, fmt.Errorf("url was empty")
-	}
-	req, err := http.NewRequest(http.MethodGet, URL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("client: could not create request: %s", err.Error())
-	}
-	req.Header.Set("User-Agent", "")
-
-	res, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("client: error making http request: %s", err)
-	}
-	resBody, err = io.ReadAll(res.Body)
-	if err != nil {
-		return nil, fmt.Errorf("client: could not read response body: %s", err)
-	}
-	return resBody, nil
 }

--- a/imageview/image.go
+++ b/imageview/image.go
@@ -17,16 +17,6 @@ import (
 	"github.com/mat/besticon/ico"
 )
 
-const RESIZE_OFFSET_Y = 8
-const RESIZE_FACTOR_Y = 2
-const RESIZE_FACTOR_X = 1
-const DEFAULT_TERM_COLS = 80
-const DEFAULT_TERM_ROWS = 24
-const FPS = 15
-
-const ANSI_CURSOR_UP = "\x1B[%dA"
-const ANSI_CURSOR_HIDE = "\x1B[?25l"
-const ANSI_CURSOR_SHOW = "\x1B[?25h"
 const ANSI_BG_TRANSPARENT_COLOR = "\x1b[0;39;49m"
 const ANSI_BG_RGB_COLOR = "\x1b[48;2;%d;%d;%dm"
 const ANSI_FG_TRANSPARENT_COLOR = "\x1b[0m "
@@ -204,25 +194,33 @@ func rescaleImageToBounds(imageDimensions tea.WindowSizeMsg, bounds tea.WindowSi
 	return output
 }
 
-func getScaledImage(image []byte, size *tea.WindowSizeMsg) string {
-	const ERROR_OUTPUT = "[-]"
+func decodeImageBytes(image []byte) (output []image.Image, err error) {
 	if len(image) < 1 {
-		return ERROR_OUTPUT
+		return output, fmt.Errorf("image bytes slice was empty")
 	}
 	decodedImages := decode(image)
-	if len(decodedImages) < 1 {
+	return decodedImages, nil
+}
+
+func getImageDimensions(image image.Image) tea.WindowSizeMsg {
+	return tea.WindowSizeMsg{
+		Height: image.Bounds().Dy(),
+		Width:  image.Bounds().Dx(),
+	}
+}
+
+func getScaledImage(frames []image.Image, size *tea.WindowSizeMsg) string {
+	const ERROR_OUTPUT = "[-]"
+	if len(frames) < 1 {
 		return ERROR_OUTPUT
 	}
-	imageDimensions := tea.WindowSizeMsg{
-		Height: decodedImages[0].Bounds().Dy(),
-		Width:  decodedImages[0].Bounds().Dx(),
-	}
+	imageDimensions := getImageDimensions(frames[0])
 	if size != nil {
 		size.Height *= 2 // multiply height by two to convert from characters to "pixels"
 		imageDimensions = rescaleImageToBounds(imageDimensions, *size)
 	}
 	rescaledImage := scale(
-		decodedImages,
+		frames,
 		imageDimensions,
 	)
 	output := escape(rescaledImage)

--- a/imageview/imageView.go
+++ b/imageview/imageView.go
@@ -1,6 +1,7 @@
 package imageview
 
 import (
+	"image"
 	"log"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -15,7 +16,7 @@ const (
 A model which handles the displaying/resizing of an image in ASCII characters
 */
 type ImageViewModel struct {
-	imageBytes        []byte            // The bytes of the original image
+	imageFrames       []image.Image     // The original image bytes' decoded color values
 	stringifiedImage  string            // The current ASCII representation of the image
 	currentDimensions tea.WindowSizeMsg // The dimensions within which to display the image
 }
@@ -24,7 +25,8 @@ type ImageViewModel struct {
 Returns a new ImageViewModel with the given image bytes
 */
 func NewImageViewModelFromBytes(imageBytes []byte) (output ImageViewModel) {
-	output.imageBytes = imageBytes
+	imageFrames, _ := decodeImageBytes(imageBytes)
+	output.imageFrames = imageFrames
 	output.RerenderImage(output.currentDimensions)
 	return
 }
@@ -48,7 +50,7 @@ func (m *ImageViewModel) RerenderImage(newDimensions tea.WindowSizeMsg) {
 	widthHasChanged := m.currentDimensions.Width != newDimensions.Width
 	heightHasChanged := m.currentDimensions.Height != newDimensions.Height
 	if widthHasChanged || heightHasChanged {
-		m.stringifiedImage = getScaledImage(m.imageBytes, &newDimensions)
+		m.stringifiedImage = getScaledImage(m.imageFrames, &newDimensions)
 	}
 }
 

--- a/imageview/imageView.go
+++ b/imageview/imageView.go
@@ -2,7 +2,6 @@ package imageview
 
 import (
 	"image"
-	"log"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -29,17 +28,6 @@ func NewImageViewModelFromBytes(imageBytes []byte) (output ImageViewModel) {
 	output.imageFrames = imageFrames
 	output.RerenderImage(output.currentDimensions)
 	return
-}
-
-/*
-Returns an ImageViewModel with image bytes from an http request to the given URL
-*/
-func NewImageViewModelFromURL(imageURL string) ImageViewModel {
-	newImageBytes, err := getImageBytesFromURL(imageURL)
-	if err != nil {
-		log.Fatalf("error getting the image bytes from the URL: %s - %v", imageURL, err)
-	}
-	return NewImageViewModelFromBytes(newImageBytes)
 }
 
 /*

--- a/linearcontainer/linearcontainer.go
+++ b/linearcontainer/linearcontainer.go
@@ -151,14 +151,20 @@ func (m LinearContainerModel) GetComponentStyleByIndex(componentIdx int) lipglos
 	return m.GetComponentStyle(m.GetComponent(componentIdx))
 }
 
+/*
+Returns the string rendering of the given component (including the border given to it by
+the linear container) if it were to be resized to the given size
+*/
 func (m LinearContainerModel) viewComponentAtSize(component con.Component, size tea.WindowSizeMsg) string {
 	component.Update(size)
 	return m.ViewComponent(&component)
 }
 
 /*
-Sets the size of one of LinearContainerModel's components according to the available space
-laid out by containerSize and the Component's max/min width/height
+Given a target size, the returns the size a specific component should be set to, according to
+the available space laid out by containerSize and the Component's max/min width/height. It also
+includes logic to keep a component from growing beyond the maximum dimensions of its content,
+if the component has shrinkToContent set to true
 
 componentIdx: int - The index of the component in the LinearContainerModel's
 list of Components
@@ -172,27 +178,26 @@ refer to the width of components)
 */
 func (m LinearContainerModel) getNewComponentSize(componentIdx int, containerSize tea.WindowSizeMsg, newSize int) (newMsg tea.WindowSizeMsg, hitMaxSize bool) {
 	newMsg = containerSize
-	component := m.GetComponent(componentIdx)
+	component := m.GetComponent(componentIdx) // For brevity, get the component at componentIdx
 	if m.IsHorizontal() {
-		// Use as much of the WindowSizeMsg's hight as the Component's MaximumHeight will allow
-		newMsg.Height = component.GetClampedHeight(containerSize.Height)
-		newMsg.Width = component.GetClampedWidth(newSize)
+		newMsg.Height = component.GetClampedHeight(containerSize.Height) // Height isn't the major axis, so use as much of the WindowSizeMsg's hight as the Component's MaximumHeight will allow
+		newMsg.Width = component.GetClampedWidth(newSize)                // Width is the major axis, so try to set the width of the new dimensions to newSize
 
 		if component.ShrinkToContent() {
-			widthOfContentAtNewSize := lipgloss.Width(m.viewComponentAtSize(*component, newMsg))
-			if widthOfContentAtNewSize < newMsg.Width {
-				newMsg.Width = component.GetClampedWidth(widthOfContentAtNewSize)
+			widthOfContentAtNewSize := lipgloss.Width(m.viewComponentAtSize(*component, newMsg)) // Calculate what the width of the components view would be at the proposed new size
+			if widthOfContentAtNewSize < newMsg.Width {                                          // If resizing this component to this new size would leave some empty space when its model had rendered
+				newMsg.Width = component.GetClampedWidth(widthOfContentAtNewSize) // Set its width to however much its model would actually use
 				hitMaxSize = true
 			}
 		}
 	} else {
-		// Use as much of the WindowSizeMsg's width as the Component's MaximumWidth will allow
-		newMsg.Width = component.GetClampedWidth(containerSize.Width)
-		newMsg.Height = component.GetClampedHeight(newSize)
+
+		newMsg.Width = component.GetClampedWidth(containerSize.Width) // Width isn't the major axis, so use as much of the WindowSizeMsg's width as the Component's MaximumWidth will allow
+		newMsg.Height = component.GetClampedHeight(newSize)           // Height is the major axis, so try to set the height of the new dimensions to newSize
 		if component.ShrinkToContent() {
-			heightOfContentAtNewSize := lipgloss.Height(m.viewComponentAtSize(*component, newMsg))
-			if heightOfContentAtNewSize < newMsg.Height {
-				newMsg.Height = component.GetClampedHeight(heightOfContentAtNewSize)
+			heightOfContentAtNewSize := lipgloss.Height(m.viewComponentAtSize(*component, newMsg)) // Calculate what the height of the components view would be at the proposed new size
+			if heightOfContentAtNewSize < newMsg.Height {                                          // If resizing this component to this new size would leave some empty space when its model had rendered
+				newMsg.Height = component.GetClampedHeight(heightOfContentAtNewSize) // Set its height to however much its model would actually use
 				hitMaxSize = true
 			}
 		}
@@ -272,7 +277,6 @@ func (m *LinearContainerModel) ResizeComponents(containerSize tea.WindowSizeMsg)
 			)
 			sizes[componentIdx] = newSize
 			// if the component hit its maximum size
-			// DEBUG: m.GetSizeAlongMajorAxis(newSize) >= m.getMaximumSize(*(m.GetComponent(componentIdx)))
 			if hitMaxSize {
 				// remove it from the list of growable components
 				growableComponents = slices.Delete(

--- a/linearcontainer/linearcontainer.go
+++ b/linearcontainer/linearcontainer.go
@@ -1,6 +1,8 @@
 package linearcontainer
 
 import (
+	"fmt"
+	"os"
 	"slices"
 	"sort"
 
@@ -152,6 +154,15 @@ func (m LinearContainerModel) GetComponentStyleByIndex(componentIdx int) lipglos
 	return m.GetComponentStyle(m.GetComponent(componentIdx))
 }
 
+func (m LinearContainerModel) viewComponentAtSize(component con.Component, size tea.WindowSizeMsg) string {
+	fmt.Fprintf(os.Stderr, "Old component size: %+v\n", component.GetSize())
+	component.SetSize(size)
+	newModel, _ := component.GetModel().Update(size)
+	component.SetModel(newModel)
+	fmt.Fprintf(os.Stderr, "New component size: %+v\n", component.GetSize())
+	return m.ViewComponent(&component)
+}
+
 /*
 Sets the size of one of LinearContainerModel's components according to the available space
 laid out by containerSize and the Component's max/min width/height
@@ -166,8 +177,8 @@ newSize: int - The new size of the major axis of the Component (if the
 LinearContainerModel has direction horizontal, the new size would
 refer to the width of components)
 */
-func (m LinearContainerModel) getNewComponentSize(componentIdx int, containerSize tea.WindowSizeMsg, newSize int) tea.WindowSizeMsg {
-	newMsg := containerSize
+func (m LinearContainerModel) getNewComponentSize(componentIdx int, containerSize tea.WindowSizeMsg, newSize int) (newMsg tea.WindowSizeMsg, hitMaxSize bool) {
+	newMsg = containerSize
 	component := m.GetComponent(componentIdx)
 	if m.IsHorizontal() {
 		// Use as much of the WindowSizeMsg's hight as the Component's MaximumHeight will allow
@@ -176,12 +187,31 @@ func (m LinearContainerModel) getNewComponentSize(componentIdx int, containerSiz
 			component.GetMinimumHeight(),
 			component.GetMaximumHeight(),
 		)
-
 		newMsg.Width = utils.ClampInt(
 			newSize,
 			component.GetMinimumWidth(),
 			component.GetMaximumWidth(),
 		)
+		// if the component shrinks to its content
+		//	get the width of its content at the proposed newMsg size
+		//  and set the newMsg width to that width
+		if component.ShrinkToContent() {
+			widthOfContentAtNewSize := lipgloss.Width(m.viewComponentAtSize(*component, newMsg))
+			fmt.Fprintf(os.Stderr, "newMsg.Width: %d\n", newMsg.Width)
+			fmt.Fprintf(os.Stderr, "Width of content at new size: %d\n", widthOfContentAtNewSize)
+			if widthOfContentAtNewSize < newMsg.Width {
+				newMsg.Width = utils.ClampInt(
+					widthOfContentAtNewSize,
+					component.GetMinimumWidth(),
+					component.GetMaximumWidth(),
+				)
+				fmt.Fprintf(os.Stderr, "Updated width of newMsg: %d\n", newMsg.Width)
+				hitMaxSize = true
+			}
+		}
+		if newMsg.Width >= component.GetMaximumWidth() {
+			hitMaxSize = true
+		}
 	} else {
 		// Use as much of the WindowSizeMsg's width as the Component's MaximumWidth will allow
 		newMsg.Width = utils.ClampInt(
@@ -195,8 +225,11 @@ func (m LinearContainerModel) getNewComponentSize(componentIdx int, containerSiz
 			component.GetMinimumHeight(),
 			component.GetMaximumHeight(),
 		)
+		if newMsg.Height >= component.GetMaximumHeight() {
+			hitMaxSize = true
+		}
 	}
-	return newMsg
+	return
 }
 
 /*
@@ -229,7 +262,7 @@ func (m *LinearContainerModel) ResizeComponents(containerSize tea.WindowSizeMsg)
 
 	// 1. set every component to its minimum width
 	for i := range len(m.GetComponents()) {
-		newSize := m.getNewComponentSize(i, containerSize, m.getMinimumSize(*(m.GetComponent(i))))
+		newSize, _ := m.getNewComponentSize(i, containerSize, m.getMinimumSize(*(m.GetComponent(i))))
 		sizes = append(sizes, newSize)
 		// if the component can still grow
 		if m.GetSizeAlongMajorAxis(newSize) < m.getMaximumSize(*(m.GetComponent(i))) {
@@ -261,14 +294,15 @@ func (m *LinearContainerModel) ResizeComponents(containerSize tea.WindowSizeMsg)
 		for growableIdx := 0; growableIdx < len(growableComponents); growableIdx++ {
 			// try to grow each growable component to an even share of the remaining space
 			componentIdx := growableComponents[growableIdx] // get the index of the component in m.Components
-			newSize := m.getNewComponentSize(
+			newSize, hitMaxSize := m.getNewComponentSize(
 				componentIdx,
 				containerSize,
 				m.GetSizeAlongMajorAxis(sizes[componentIdx])+evenShare,
 			)
 			sizes[componentIdx] = newSize
 			// if the component hit its maximum size
-			if m.GetSizeAlongMajorAxis(newSize) >= m.getMaximumSize(*(m.GetComponent(componentIdx))) {
+			// DEBUG: m.GetSizeAlongMajorAxis(newSize) >= m.getMaximumSize(*(m.GetComponent(componentIdx)))
+			if hitMaxSize {
 				// remove it from the list of growable components
 				growableComponents = slices.Delete(
 					growableComponents,
@@ -286,7 +320,7 @@ func (m *LinearContainerModel) ResizeComponents(containerSize tea.WindowSizeMsg)
 	if len(growableComponents) > 0 && evenShare < 1 {
 		// give all remaining space to the growable with the highest priority
 		componentIdx := growableComponents[0] // get the index of the component in m.Components
-		newSize := m.getNewComponentSize(
+		newSize, _ := m.getNewComponentSize(
 			componentIdx,
 			containerSize,
 			m.GetSizeAlongMajorAxis(sizes[componentIdx])+remainingSpace,
@@ -328,7 +362,7 @@ func (m LinearContainerModel) GetFullContainerSize() (output tea.WindowSizeMsg) 
 	return
 }
 
-func (m LinearContainerModel) ViewComponent(model tea.Model, component *con.Component) string {
+func (m LinearContainerModel) ViewComponent(component *con.Component) string {
 	if lc, isLC := component.GetModel().(LinearContainerModel); isLC {
 		// if component is a LinearContainerModel, make sure it gets m's FocusHandler
 		lc.SetFocusHandler(
@@ -372,7 +406,7 @@ func (m LinearContainerModel) View() (s string) {
 	var views []string
 	// Collect all the individual renderings for all the components
 	for _, component := range m.GetVisibleComponents() {
-		views = append(views, m.ViewComponent(component.GetModel(), component))
+		views = append(views, m.ViewComponent(component))
 	}
 	// Join component renderings together
 	if m.IsHorizontal() {

--- a/linearcontainer/linearcontainer.go
+++ b/linearcontainer/linearcontainer.go
@@ -1,8 +1,6 @@
 package linearcontainer
 
 import (
-	"fmt"
-	"os"
 	"slices"
 	"sort"
 
@@ -10,7 +8,6 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	con "github.com/argotnaut/vanitea/container"
-	utils "github.com/argotnaut/vanitea/utils"
 )
 
 const (
@@ -155,11 +152,7 @@ func (m LinearContainerModel) GetComponentStyleByIndex(componentIdx int) lipglos
 }
 
 func (m LinearContainerModel) viewComponentAtSize(component con.Component, size tea.WindowSizeMsg) string {
-	fmt.Fprintf(os.Stderr, "Old component size: %+v\n", component.GetSize())
-	component.SetSize(size)
-	newModel, _ := component.GetModel().Update(size)
-	component.SetModel(newModel)
-	fmt.Fprintf(os.Stderr, "New component size: %+v\n", component.GetSize())
+	component.Update(size)
 	return m.ViewComponent(&component)
 }
 
@@ -182,52 +175,26 @@ func (m LinearContainerModel) getNewComponentSize(componentIdx int, containerSiz
 	component := m.GetComponent(componentIdx)
 	if m.IsHorizontal() {
 		// Use as much of the WindowSizeMsg's hight as the Component's MaximumHeight will allow
-		newMsg.Height = utils.ClampInt(
-			containerSize.Height,
-			component.GetMinimumHeight(),
-			component.GetMaximumHeight(),
-		)
-		newMsg.Width = utils.ClampInt(
-			newSize,
-			component.GetMinimumWidth(),
-			component.GetMaximumWidth(),
-		)
+		newMsg.Height = component.GetClampedHeight(containerSize.Height)
+		newMsg.Width = component.GetClampedWidth(newSize)
 		// if the component shrinks to its content
 		//	get the width of its content at the proposed newMsg size
 		//  and set the newMsg width to that width
 		if component.ShrinkToContent() {
 			widthOfContentAtNewSize := lipgloss.Width(m.viewComponentAtSize(*component, newMsg))
-			fmt.Fprintf(os.Stderr, "newMsg.Width: %d\n", newMsg.Width)
-			fmt.Fprintf(os.Stderr, "Width of content at new size: %d\n", widthOfContentAtNewSize)
 			if widthOfContentAtNewSize < newMsg.Width {
-				newMsg.Width = utils.ClampInt(
-					widthOfContentAtNewSize,
-					component.GetMinimumWidth(),
-					component.GetMaximumWidth(),
-				)
-				fmt.Fprintf(os.Stderr, "Updated width of newMsg: %d\n", newMsg.Width)
+				newMsg.Width = component.GetClampedWidth(widthOfContentAtNewSize)
 				hitMaxSize = true
 			}
 		}
-		if newMsg.Width >= component.GetMaximumWidth() {
-			hitMaxSize = true
-		}
+
 	} else {
 		// Use as much of the WindowSizeMsg's width as the Component's MaximumWidth will allow
-		newMsg.Width = utils.ClampInt(
-			containerSize.Width,
-			component.GetMinimumWidth(),
-			component.GetMaximumWidth(),
-		)
-
-		newMsg.Height = utils.ClampInt(
-			newSize,
-			component.GetMinimumHeight(),
-			component.GetMaximumHeight(),
-		)
-		if newMsg.Height >= component.GetMaximumHeight() {
-			hitMaxSize = true
-		}
+		newMsg.Width = component.GetClampedWidth(containerSize.Width)
+		newMsg.Height = component.GetClampedHeight(newSize)
+	}
+	if newMsg.Width >= component.GetMaximumWidth() || newMsg.Height >= component.GetMaximumHeight() {
+		hitMaxSize = true
 	}
 	return
 }

--- a/linearcontainer/linearcontainer.go
+++ b/linearcontainer/linearcontainer.go
@@ -177,9 +177,7 @@ func (m LinearContainerModel) getNewComponentSize(componentIdx int, containerSiz
 		// Use as much of the WindowSizeMsg's hight as the Component's MaximumHeight will allow
 		newMsg.Height = component.GetClampedHeight(containerSize.Height)
 		newMsg.Width = component.GetClampedWidth(newSize)
-		// if the component shrinks to its content
-		//	get the width of its content at the proposed newMsg size
-		//  and set the newMsg width to that width
+
 		if component.ShrinkToContent() {
 			widthOfContentAtNewSize := lipgloss.Width(m.viewComponentAtSize(*component, newMsg))
 			if widthOfContentAtNewSize < newMsg.Width {
@@ -187,11 +185,17 @@ func (m LinearContainerModel) getNewComponentSize(componentIdx int, containerSiz
 				hitMaxSize = true
 			}
 		}
-
 	} else {
 		// Use as much of the WindowSizeMsg's width as the Component's MaximumWidth will allow
 		newMsg.Width = component.GetClampedWidth(containerSize.Width)
 		newMsg.Height = component.GetClampedHeight(newSize)
+		if component.ShrinkToContent() {
+			heightOfContentAtNewSize := lipgloss.Height(m.viewComponentAtSize(*component, newMsg))
+			if heightOfContentAtNewSize < newMsg.Height {
+				newMsg.Height = component.GetClampedHeight(heightOfContentAtNewSize)
+				hitMaxSize = true
+			}
+		}
 	}
 	if newMsg.Width >= component.GetMaximumWidth() || newMsg.Height >= component.GetMaximumHeight() {
 		hitMaxSize = true


### PR DESCRIPTION
<!-- Closes issue #n -->
Closes #16 
# Summary
<!-- Summarize the issue(s) fixed or features implemented in this branch -->
This branch fixes an issue where components like `ImageView` would be layed-out by containers like `LinearContainerModel` according to the same logic as any other component, but its model would only render the image as large as was possible while preserving the aspect ratio, leading to a situation where the linear container would give it a certain size, it would only use a fraction of that size, and it would end up rendering with some amount of blank space next to it (as shown [here](https://private-user-images.githubusercontent.com/161991025/573849630-1e5e9739-09f5-464f-ba77-725e1ebd1428.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzU2MDkxMDUsIm5iZiI6MTc3NTYwODgwNSwicGF0aCI6Ii8xNjE5OTEwMjUvNTczODQ5NjMwLTFlNWU5NzM5LTA5ZjUtNDY0Zi1iYTc3LTcyNWUxZWJkMTQyOC5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjYwNDA4JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI2MDQwOFQwMDQwMDVaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT1iNzc5OWRmNmE2MzNjYzllYTcwZmI5ZWY4MjY2N2QzYzkyMTliMmJlZDY1ZWI0ODgxZWM4NDBkY2Y4YTM1MWE0JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.xhqC_voX1XjoY_jDJklVwEwWGhEBJj1hev_mt2J6ldE)). This branch adds the `ShrinkToContent` and `SetShrinkToContent` functions for getting and setting this property on components, as well as logic in `LinearContainerModel` to handle it

## Example
<!-- Example of new behavior, if applicable -->
![shrink-resize](https://github.com/user-attachments/assets/7dcb05a0-bc4f-4e7c-a672-5e3a160d8d97)

## Merge checklist
- [x] Comments/documentation updated