### PR TITLE
Fixed GetActions logic in linear container

### DIFF
--- a/actionbar/actionbar.go
+++ b/actionbar/actionbar.go
@@ -236,12 +236,14 @@ func (m ActionBarModel) View() string {
 		endcap := highlightBackground.Render(" ? - help ")
 		shortcutStrings := []string{}
 		for _, action := range m.GetActions() {
-			shortcutStrings = append(
-				shortcutStrings,
-				highlightForeground.Render(
-					strings.TrimSpace(action.GetShortcut()),
-				)+" "+action.GetName(),
-			)
+			if len(strings.TrimSpace(action.GetShortcut())) > 0 {
+				shortcutStrings = append(
+					shortcutStrings,
+					highlightForeground.Render(
+						strings.TrimSpace(action.GetShortcut()),
+					)+" "+action.GetName(),
+				)
+			}
 		}
 		output := strings.TrimSpace(
 			lipgloss.DefaultRenderer().NewStyle().

--- a/appframe/appframe.go
+++ b/appframe/appframe.go
@@ -31,11 +31,6 @@ Initializes an AppFrame with the following components
 func NewAppFrame(appName string, components []*con.Component) (output AppFrame) {
 	// initialize main linear container (contains all the components except the action bar at the bottom)
 	container := lc.NewLinearContainerFromComponents(components)
-	// Get actions from linear container's components
-	var actions []con.Action
-	for _, comp := range container.GetComponents() {
-		actions = append(actions, comp.GetActions()...)
-	}
 	// initialize action bar
 	navShellForward := func(*con.Component) {
 		navshell.Forward()
@@ -63,14 +58,13 @@ func NewAppFrame(appName string, components []*con.Component) (output AppFrame) 
 	}
 	output.actionBar = actionbar.NewActionBarModel(
 		func() (newActions []con.Action) {
-			newActions = append(newActions, actions...)
-			newActions = append(newActions, con.NewDefaultAction("exit", "Exit the program", "ctrl+c", nil, nil, nil))
-			newActions = append(newActions, navShellActions...)
 			topOfNavStack := navshell.GetNavShell().Navstack.Top().Model
 			switch topOfNavStack := topOfNavStack.(type) {
 			case con.Actionable:
 				newActions = append(newActions, topOfNavStack.GetActions()...)
 			}
+			newActions = append(newActions, navShellActions...)
+			newActions = append(newActions, con.NewDefaultAction("exit", "Exit the program", "ctrl+c", nil, nil, nil))
 			return
 		},
 	)

--- a/container/component.go
+++ b/container/component.go
@@ -312,7 +312,12 @@ func (m *Component) SetShortcutPosition(shortcutPosition int) *Component {
 }
 
 func (m Component) GetActions() []Action {
-	return m.actions
+	output := m.actions
+	switch model := m.GetModel().(type) {
+	case Actionable:
+		output = append(output, model.GetActions()...)
+	}
+	return output
 }
 
 func (m *Component) SetActions(actions []Action) *Component {

--- a/examples/imageview/tui/ansiinfo.go
+++ b/examples/imageview/tui/ansiinfo.go
@@ -43,7 +43,28 @@ func NewANSIInfoModel() (output ANSIInfoModel) {
 	codeListModel := con.ComponentFromModel(
 		codeList{list: list.New(codeListItems, list.NewDefaultDelegate(), 0, 0)},
 	)
-	output.codeList = codeListModel
+
+	output.codeList = codeListModel.SetActions([]con.Action{
+		// Add an action for filtering the list (to show appframe's ability to run the actions of its container's childcomponents)
+		con.NewDefaultAction(
+			"filter",
+			"filter list",
+			"",
+			codeListModel,
+			func(c *con.Component) {
+				if codeList, isCodeList := c.GetModel().(codeList); isCodeList {
+					codeList.list.SetFilterState(list.Filtering)
+					c.SetModel(codeList)
+				}
+			},
+			func(c *con.Component) {
+				if codeList, isCodeList := c.GetModel().(codeList); isCodeList {
+					codeList.list.SetFilterState(list.Unfiltered)
+					c.SetModel(codeList)
+				}
+			},
+		),
+	})
 
 	// create the TUI of the terminal image
 	output.image = con.ComponentFromModel(


### PR DESCRIPTION
<!-- Closes issue #n -->
# Summary
<!-- Summarize the issue(s) fixed or features implemented in this branch -->
This branch fixes the `GetActions()` logic in the linear container, so that it returns the actions of all of its child components. It also updates the actionbar so that it now doesn't display actions whose shortcuts are empty strings